### PR TITLE
ID範囲指定の指定方法変更

### DIFF
--- a/sr_client.go
+++ b/sr_client.go
@@ -123,7 +123,7 @@ func (sc *SrClient) DumpTableToCSV(p SrRefParams) (*CSVWriter, error) {
 	}
 	// StockHistory、TransactionHead、TransactionDetailテーブルで全件検索の場合は範囲指定をする
 	if (p.TableName == "StockHistory" || p.TableName == "TransactionHead" || p.TableName == "TransactionDetail") && isAll {
-		startNum := 0
+		startNum := 1
 		// 1回あたりの指定可能範囲は10万件まで。idで10万までを範囲指定する
 		endNum := 100000
 		for {
@@ -133,10 +133,10 @@ func (sc *SrClient) DumpTableToCSV(p SrRefParams) (*CSVWriter, error) {
 			// 10万件の範囲指定＆id昇順にソートして取得
 			if p.TableName == "StockHistory" {
 				p.Order = []string{"id"}
-				p.Conditions[0] = map[string]*string{"id >": &startNumStr, "id <=": &endNumStr}
+				p.Conditions[0] = map[string]*string{"id >=": &startNumStr, "id <=": &endNumStr}
 			} else {
 				p.Order = []string{"transactionHeadId"}
-				p.Conditions[0] = map[string]*string{"transactionHeadId >": &startNumStr, "transactionHeadId <=": &endNumStr}
+				p.Conditions[0] = map[string]*string{"transactionHeadId >=": &startNumStr, "transactionHeadId <=": &endNumStr}
 			}
 
 			for {
@@ -167,7 +167,7 @@ func (sc *SrClient) DumpTableToCSV(p SrRefParams) (*CSVWriter, error) {
 			}
 			// 次の10万件取得用の範囲を設定
 			if lastId == endNum {
-				startNum = endNum
+				startNum = endNum + 1
 				endNum += 100000
 			} else {
 				break


### PR DESCRIPTION
# 概要
スマレジAPIの仕様で、一回のリクエストでデータをまとめて取得する場合、IDの範囲を10万以内で指定する必要がある。
2022/02/03 以降、この範囲指定がエラーになるようになったので調査対応する。

# 調査結果
調べたところ、IDの範囲指定方法を変えることで正常に動くことがわかった。
* id > 0 AND id <= 100000 : エラー
* id >=1 AND id<= 100000: 正常

上記に合わせて一旦修正。スマレジ側にも上記で問題ないかを問い合わせ中。

# テスト
ビルドし直してsumarejidumpを実行。StockHistoryをdump。
sort -rn StockHistory.csv | uniq -c で重複件数を確認し、重複レコードがないことは確認済み。
その上でデータの境界（99999、100000、100001、199999、200000、200001）のIDを確認し、範囲指定に問題がないことを確認済み。
TransactionHeadも、dumpできることは確認済み。

# 関連issue
https://github.com/nombre-premier/sumarejidump/pull/124